### PR TITLE
Remove commented-out UAT URL from proxyOptions files

### DIFF
--- a/frontend/proxyOptions.ts
+++ b/frontend/proxyOptions.ts
@@ -2,7 +2,7 @@ import common_site_config from '../../../sites/common_site_config.json';
 
 const { webserver_port } = common_site_config;
 
-const uat = 'https://uat.unityedu.tech';
+// const uat = 'https://uat.unityedu.tech';
 
 export default {
   '^/(app|api|assets|files|private)': {

--- a/new_frontend/proxyOptions.ts
+++ b/new_frontend/proxyOptions.ts
@@ -2,7 +2,7 @@ import common_site_config from '../../../sites/common_site_config.json';
 
 const { webserver_port } = common_site_config;
 
-const uat = 'https://uat.unityedu.tech';
+// const uat = 'https://uat.unityedu.tech';
 
 export default {
   '^/(app|api|assets|files|private)': {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the use of the UAT environment URL in the proxy configuration by commenting it out. No changes to existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->